### PR TITLE
Fix calculation of watt hours for API submission

### DIFF
--- a/esphome/components/powerpal_ble/powerpal_ble.cpp
+++ b/esphome/components/powerpal_ble/powerpal_ble.cpp
@@ -78,7 +78,7 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
     }
 
     if (this->watt_hours_sensor_ != nullptr) {
-      int mywatt_hrs = (uint32_t)roundf(pulses_within_interval * (this->pulses_per_kwh_ / kw_to_w_conversion));
+      int mywatt_hrs = (uint32_t)roundf(((float)pulses_within_interval) / (this->pulses_per_kwh_ / kw_to_w_conversion));
        this->watt_hours_sensor_->publish_state(mywatt_hrs);
     }
      if (this->timestamp_sensor_ != nullptr) {


### PR DESCRIPTION
I was getting astronomical figures reported to Powerpal Cloud!

Example from Powerpal app:

```
    "pulses": 15,
    "watt_hours": 4.6875,
```

Example from ESPHome:

```
    "pulses": 15, 
    "watt_hours": 48,
```

Noticed that this was off by a factor of 3.2^2, and tracked it down to this line of code.